### PR TITLE
 S4R-9341 | update gb ios tracker to support conversational origin #16 

### DIFF
--- a/Docs/autoSearch.md
+++ b/Docs/autoSearch.md
@@ -51,7 +51,10 @@ let tracker = GbTracker(customerId: customerId, area: area, login: login)
 let results = exampleSearchRequest()
 
 // Prepare event for beacon
+// For standard search origin:
 let event = AutoSearchEvent(origin: Origin.search, searchID: results.searchId)
+// For R2 Conversational Commerce origin:
+// let event = AutoSearchEvent(origin: Origin.conversation, searchID: results.searchId)
 
 // Prepare beacon for request
 let beacon = AutoSearchBeacon(event: event, experiments: nil, metadata: nil)
@@ -98,7 +101,7 @@ AutoSearchEvent:
 | Property | Description | Swift type | Required? | Min | Max | String format |
 | -------- | ----------- | --------- | --------- | --- | --- | ------------- |
 | searchId | The ID of the search performed with the GroupBy search engine API. This ID is returned in each HTTP response from the API and must be included in this event. | `String` | Yes | n/a | n/a | n/a |
-| origin | The context in which the search was performed. Acceptable values are \"search\" (used when a search query is used with the API), \"sayt\" (used when GroupBy's SAYT search engine API is used instead of its regular search engine API, for search-as-you-type use cases), and \"navigation\" (used when no search query is used because the search engine is being used to power a PLP consisting of a category of products, often after a shopper has selected a facet). | `Origin` enum value | Yes | n/a | n/a | n/a |
+| origin | The context in which the search was performed. Acceptable values are \"search\" (used when a search query is used with the API), \"sayt\" (used when GroupBy's SAYT search engine API is used instead of its regular search engine API, for search-as-you-type use cases), \"navigation\" (used when no search query is used because the search engine is being used to power a PLP consisting of a category of products, often after a shopper has selected a facet), and \"conversation\" (used when the search originated from a Conversational Commerce interaction). | `Origin` enum value | Yes | n/a | n/a | n/a |
 
 AutoSearchBeacon:
 

--- a/Docs/validation.md
+++ b/Docs/validation.md
@@ -16,7 +16,10 @@ func sendAutoSearchEvent() {
     // Code below assumes a tracker has been created called "tracker"
 
     // Prepare event for beacon
+    // For standard search origin:
     let event = AutoSearchEvent(origin: Origin.search, searchID: "167e44d4-2140-4098-91b0-1e1f0558fd8c")
+    // For R2 Conversational Commerce origin use:
+    // let event = AutoSearchEvent(origin: Origin.conversation, searchID: "167e44d4-2140-4098-91b0-1e1f0558fd8c")
 
     // Prepare beacon for request
     let beacon = AutoSearchBeacon(event: event, experiments: nil, metadata: nil)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,36 @@ The following event types are supported in the client. The "main four" event typ
 
 When at least the main four event types have been implemented, session level insights become available instead of just event level insights. For example, you can get a breakdown via GroupBy's analytics of which search terms are leading your shoppers to the products they're buying.
 
+## Conversational Commerce origin
+
+R2 Conversational Commerce beacons must set the autoSearch event origin to `conversation` so analytics can differentiate these interactions from other origins like `search`, `sayt`, and `navigation`.
+
+- Swift example:
+
+```swift
+let event = AutoSearchEvent(origin: .conversation, searchID: "<response_id>")
+let beacon = AutoSearchBeacon(event: event, experiments: nil, metadata: nil)
+tracker.sendAutoSearchEvent(autoSearchBeacon: beacon, completion: { _ in })
+```
+
+- Example JSON payload fragment (what the SDK encodes):
+
+```json
+{
+  "event": {
+    "origin": "conversation",
+    "searchId": "<response_id>"
+  }
+}
+```
+
+QA:
+- Example of an autoSearch event with origin.conversation=true? See JSON above; the flag is represented by `"origin":"conversation"` in the payload. 
+- Do we need to send a search request or a search event with origin.conversation=true for autoSearch to work? Only the autoSearch event needs `origin` set to `conversation`; you do not need to send a separate directSearch from the app (that is handled by the Conversational API team). Ensure `searchId`/`response_id` is populated.
+- Will the change inside gb-ios-tracker be huge to support this? No — the SDK now includes a new `Origin.conversation` enum case; update your call sites to pass `.conversation` when sending autoSearch for conversational responses.
+
+See [autoSearch docs](Docs/autoSearch.md) for details and examples.
+
 ## Including metadata and experiments in events
 
 ### Metadata

--- a/Sources/GroupByTracker/Model/Origin.swift
+++ b/Sources/GroupByTracker/Model/Origin.swift
@@ -2,12 +2,14 @@ import Foundation
 
 /// The context in which the search was performed. Acceptable values are "search" (used when
 /// a search query is used with the API), "sayt" (used when GroupBy's SAYT search engine API
-/// is used instead of its regular search engine API, for search-as-you-type use cases), and
+/// is used instead of its regular search engine API, for search-as-you-type use cases),
 /// "navigation" (used when no search query is used because the search engine is being used
 /// to power a PLP consisting of a category of products, often after a shopper has selected a
-/// facet).
+/// facet), and "conversation" (used when the search originated from a Conversational Commerce
+/// interaction).
 public enum Origin: String, Codable, Hashable {
     case navigation = "navigation"
     case sayt = "sayt"
     case search = "search"
+    case conversation = "conversation"
 }

--- a/Tests/GroupByTrackerTests/GroupByTrackerTests.swift
+++ b/Tests/GroupByTrackerTests/GroupByTrackerTests.swift
@@ -3,6 +3,15 @@ import XCTest
 
 final class GroupByTrackerTests: XCTestCase {
     
+    func testOriginConversationJSONEncoding() throws {
+        let sid = UUID().uuidString.lowercased()
+        let event = AutoSearchEvent(origin: Origin.conversation, searchID: sid)
+        let data = try event.jsonData()
+        let json = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertTrue(json.contains("\"origin\":\"conversation\""), "origin should encode as 'conversation' in JSON")
+        XCTAssertTrue(json.contains("\"searchId\":"), "searchId key should be present")
+    }
+
     func testExample() throws {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct


### PR DESCRIPTION
Adds support for tracking events originating from Conversational Commerce interactions.

This includes:
- Adding a new `conversation` case to the `Origin` enum.
- Updating documentation to reflect the new origin.
- Adding an example of how to use the new origin.

The new origin allows analytics to differentiate these interactions from other origins like `search`, `sayt`, and `navigation`.